### PR TITLE
Improve chart toggle behavior and defaults

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,7 +34,7 @@ When you have new myAir data to add to the dashboard:
    ```
 
 7. The script extracts the records, splits them by month, strips unused fields, and writes to `data/monthlySleepRecords/YYYY-MM.json` (overwriting existing files for those months)
-8. Commit and push.
+8. Verify the build, then create a branch, commit, push, and open a PR.
 
 ## Available scripts
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "My Resmed Sleep Data Dashboard",
+  title: "Kevin’s Resmed Sleep Data Dashboard",
   description:
     "I built this Sleep Data Dashboard to view my `Resmed myAir` data with different timelines - Built with Next.js, React, Tailwind CSS, and TypeScript",
 };

--- a/src/app/sleep-data/chart-constants.ts
+++ b/src/app/sleep-data/chart-constants.ts
@@ -6,7 +6,7 @@ import type { ApexFormatterOpts, ApexOptions } from "apexcharts";
 
 import type { TChartDataPoint, TTabNames } from "@/lib/data-types";
 
-export const ANIMATION_THRESHOLD = 180; // Switch to area charts above this point to avoid Apex animation performance issues
+export const LONG_RANGE_THRESHOLD = 180; // Day count threshold for "long range" (default area charts)
 
 // https://stackoverflow.com/a/35970186/7082724
 function invertColor(hex: string) {

--- a/src/app/sleep-data/chart-constants.ts
+++ b/src/app/sleep-data/chart-constants.ts
@@ -28,15 +28,7 @@ function invertColor(hex: string) {
   return "#" + r.padStart(2, "0") + g.padStart(2, "0") + b.padStart(2, "0");
 }
 
-export const tabMap: { [key: number]: TTabNames } = {
-  0: "hours",
-  1: "leak",
-  2: "events",
-  3: "mask",
-  4: "score",
-};
-
-const yAxisOptionsBase = {
+const yAxisOptionsBase: ApexOptions["yaxis"] = {
   axisTicks: { show: true },
   axisBorder: { show: true },
   labels: {
@@ -46,38 +38,44 @@ const yAxisOptionsBase = {
   },
 };
 
-const yAxisOptionsHours = {
-  max: 600,
-  min: 0,
+const yAxisOptionsHours: ApexOptions["yaxis"] = {
   labels: {
     formatter: function (d: number) {
-      return `${Math.floor(d / 60)}`;
+      return `${Math.floor(d / 30) / 2}`;
     },
   },
+  max: (d: number) => (d < 600 ? 600 : Math.floor(d / 60) * 60),
+  stepSize: 60,
   title: {
     text: "Hours",
   },
 };
 
-const yAxisOptionsLeak = {
+const yAxisOptionsLeak: ApexOptions["yaxis"] = {
   title: {
     text: "Leak (L/min)",
   },
 };
 
-const yAxisOptionsEvents = {
+const yAxisOptionsEvents: ApexOptions["yaxis"] = {
+  labels: {
+    formatter: function formatter(d: number) {
+      return `${d}`;
+    },
+  },
+  max: (d: number) => (d < 3 ? 3 : Math.floor(d)),
   title: {
     text: "Events",
   },
 };
 
-const yAxisOptionsMask = {
+const yAxisOptionsMask: ApexOptions["yaxis"] = {
   title: {
     text: "On/Off",
   },
 };
 
-const yAxisOptionsScore = {
+const yAxisOptionsScore: ApexOptions["yaxis"] = {
   max: 100,
   title: {
     text: "Score",
@@ -102,6 +100,10 @@ const yAxisOptions = {
     ...yAxisOptionsMask,
   },
   score: {
+    ...yAxisOptionsBase,
+    ...yAxisOptionsScore,
+  },
+  scoreBreakdown: {
     ...yAxisOptionsBase,
     ...yAxisOptionsScore,
   },
@@ -158,15 +160,7 @@ function formatTooltipYValue(value: number, opts?: ApexFormatterOpts): string {
 export const options: ApexOptions = {
   chart: {
     animations: {
-      enabled: true,
-      speed: 500,
-      animateGradually: {
-        enabled: false,
-      },
-      dynamicAnimation: {
-        enabled: true,
-        speed: 350,
-      },
+      enabled: false,
     },
     fontFamily: "Inter, sans-serif",
     dropShadow: {
@@ -228,10 +222,9 @@ export const options: ApexOptions = {
 
 function getChartOptions(tab: TTabNames): ApexOptions {
   // For the score breakdown we reuse the 'score' y-axis but enable stacked bars and legend
-  const yaxis = tab === "scoreBreakdown" ? yAxisOptions["score"] : yAxisOptions[tab];
   const base: ApexOptions = {
     ...options,
-    yaxis,
+    yaxis: yAxisOptions[tab],
   };
 
   if (tab === "scoreBreakdown") {

--- a/src/app/sleep-data/page-content.tsx
+++ b/src/app/sleep-data/page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { ChangeEvent } from "react";
 
 import dynamic from "next/dynamic";
@@ -10,7 +10,7 @@ import { AutoSizer } from "react-virtualized-auto-sizer";
 import SegmentedToggle from "@/components/SegmentedToggle";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { ANIMATION_THRESHOLD, chartOptions, series } from "./chart-constants";
+import { LONG_RANGE_THRESHOLD, chartOptions, series } from "./chart-constants";
 import { movingAverage } from "./chart-utils";
 import MyTabTriggerTitle from "./my-tab-trigger-title";
 
@@ -30,27 +30,15 @@ function PageContent({ data }: { data: TAllData }) {
     return xDaysAgo.toISOString().split("T")[0];
   });
   const [endDate, setEndDate] = useState(data.newestDate);
-  const [useColumnsOverride, setUseColumnsOverride] = useState(false);
+  const [useColumnsOverride, setUseColumnsOverride] = useState(() => INITIAL_STARTDATE_DAYS_AGO < LONG_RANGE_THRESHOLD);
   const [pendingTab, setPendingTab] = useState<TTabNames | null>(null);
   const [currentTab, setCurrentTab] = useState<TTabNames>(INITIAL_TAB);
   const toggleGen = useRef(0);
-  const prevDisableAnimations = useRef(false);
   const startTs = new Date(startDate).getTime();
   const endTs = new Date(endDate).getTime();
 
-  const dayCount = useMemo(() => {
-    return Math.round((endTs - startTs) / (24 * 60 * 60 * 1000));
-  }, [startTs, endTs]);
-
-  const disableAnimations = dayCount >= ANIMATION_THRESHOLD;
-  const chartKey = disableAnimations ? "wide" : "narrow";
-
-  useEffect(() => {
-    if (prevDisableAnimations.current !== disableAnimations) {
-      prevDisableAnimations.current = disableAnimations;
-      if (disableAnimations) setUseColumnsOverride(false);
-    }
-  }, [disableAnimations]);
+  const dayCount = Math.round((endTs - startTs) / (24 * 60 * 60 * 1000));
+  const isLongRange = dayCount >= LONG_RANGE_THRESHOLD;
 
   // Toggle between area and column chart for the current tab.
   // Increment a generation counter to cancel stale toggles — if the user
@@ -68,6 +56,11 @@ function PageContent({ data }: { data: TAllData }) {
         setPendingTab(null);
       });
     });
+  }
+
+  function resetColumnsForRange(start: Date, end: Date) {
+    const rangeDays = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
+    setUseColumnsOverride(rangeDays < LONG_RANGE_THRESHOLD);
   }
 
   const filteredData = useMemo(() => {
@@ -92,8 +85,6 @@ function PageContent({ data }: { data: TAllData }) {
   }, [data, startTs, endTs]);
 
   const dynamicChartOptions: Record<TTabNames, ApexOptions> = useMemo(() => {
-    if (!disableAnimations) return chartOptions;
-
     const areaStrokeMain: ApexOptions["stroke"] = { width: [2, 4] };
     const areaStrokeBreakdown: ApexOptions["stroke"] = { width: [2, 2, 2, 2, 4] };
     const colStrokeMain: ApexOptions["stroke"] = { width: [0, 4] };
@@ -110,14 +101,14 @@ function PageContent({ data }: { data: TAllData }) {
           const { plotOptions: _, ...noPlot } = opts;
           return {
             ...noPlot,
-            chart: { ...noPlot.chart, animations: { enabled: false }, stackOnlyBar: false },
+            chart: { ...noPlot.chart!, animations: isLongRange ? { enabled: false } : { ...noPlot.chart!.animations, speed: 350 }, stackOnlyBar: false },
             stroke: areaStrokeBreakdown,
             fill: { type: "solid" },
           };
         }
         return {
           ...opts,
-          chart: { ...opts.chart, animations: { enabled: false } },
+          chart: { ...opts.chart, ...(isLongRange ? { animations: { enabled: false } } : {}) },
           stroke: colStrokeBreakdown,
           fill: colFill,
         };
@@ -125,7 +116,7 @@ function PageContent({ data }: { data: TAllData }) {
 
       return {
         ...opts,
-        chart: { ...opts.chart, animations: { enabled: false } },
+        chart: { ...opts.chart, ...(isLongRange ? { animations: { enabled: false } } : useArea ? { animations: { ...opts.chart!.animations, speed: 350 } } : {}) },
         stroke: useArea ? areaStrokeMain : colStrokeMain,
         fill: useArea ? areaFill : colFill,
       };
@@ -139,13 +130,10 @@ function PageContent({ data }: { data: TAllData }) {
       score: getOpts("score"),
       scoreBreakdown: getOpts("scoreBreakdown"),
     };
-  }, [disableAnimations, useColumnsOverride, currentTab]);
+  }, [isLongRange, useColumnsOverride, currentTab]);
 
   const chartSeries = useMemo(() => {
-    const useWide = dayCount >= ANIMATION_THRESHOLD;
-
     const typeFor = (tab: TTabNames) => {
-      if (!useWide) return "column";
       if (useColumnsOverride && tab === currentTab) return "column";
       return "area";
     };
@@ -181,7 +169,7 @@ function PageContent({ data }: { data: TAllData }) {
         { ...series.scoreBreakdown[4], data: xy(movingAverage(filteredData.score, 7)) },
       ],
     };
-  }, [filteredData, dayCount, useColumnsOverride, currentTab]);
+  }, [filteredData, useColumnsOverride, currentTab]);
 
   function handlePresetChange(event: ChangeEvent<HTMLSelectElement>) {
     const nextPreset = event.target.value as TSelectedPreset;
@@ -254,16 +242,21 @@ function PageContent({ data }: { data: TAllData }) {
     }
     setStartDate(start.toISOString().split("T")[0]);
     setEndDate(end.toISOString().split("T")[0]);
+    resetColumnsForRange(start, end);
   }
 
   function handleStartDateChange(event: ChangeEvent<HTMLInputElement>) {
+    const newStart = new Date(event.target.value);
     setSelectedPreset("custom");
     setStartDate(event.target.value);
+    resetColumnsForRange(newStart, new Date(endDate));
   }
 
   function handleEndDateChange(event: ChangeEvent<HTMLInputElement>) {
+    const newEnd = new Date(event.target.value);
     setSelectedPreset("custom");
     setEndDate(event.target.value);
+    resetColumnsForRange(new Date(startDate), newEnd);
   }
 
   return (
@@ -329,20 +322,18 @@ function PageContent({ data }: { data: TAllData }) {
               max={data.newestDate}
             />
           </div>
-          {disableAnimations && (
-            <div className="flex items-center gap-3">
-              <label className="text-sm font-semibold whitespace-nowrap text-accent-500">Chart Type</label>
-              <SegmentedToggle
-                options={[
-                  { label: "Area", value: "area" },
-                  { label: "Columns", value: "columns" },
-                ]}
-                value={useColumnsOverride ? "columns" : "area"}
-                onChange={() => toggleColumn()}
-                disabled={pendingTab === currentTab}
-              />
-            </div>
-          )}
+          <div className="flex items-center gap-3">
+            <label className="text-sm font-semibold whitespace-nowrap text-accent-500">Chart Type</label>
+            <SegmentedToggle
+              options={[
+                { label: "Area", value: "area" },
+                { label: "Columns", value: "columns" },
+              ]}
+              value={useColumnsOverride ? "columns" : "area"}
+              onChange={() => toggleColumn()}
+              disabled={pendingTab === currentTab}
+            />
+          </div>
         </div>
       </div>
 
@@ -354,7 +345,7 @@ function PageContent({ data }: { data: TAllData }) {
                 value={currentTab}
                 onValueChange={(v) => {
                   setCurrentTab(v as TTabNames);
-                  setUseColumnsOverride(false);
+                  if (isLongRange) setUseColumnsOverride(!isLongRange);
                   setPendingTab(null);
                   toggleGen.current++;
                 }}
@@ -404,7 +395,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="hours" className="relative">
                       {currentTab === "hours" && (
                         <Chart
-                          key={`hours-${chartKey}-${useColumnsOverride}`}
+                          key={`hours-${useColumnsOverride}`}
                           options={dynamicChartOptions.hours}
                           series={chartSeries.hours}
                           height={height}
@@ -415,7 +406,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="leak" className="relative">
                       {currentTab === "leak" && (
                         <Chart
-                          key={`leak-${chartKey}-${useColumnsOverride}`}
+                          key={`leak-${useColumnsOverride}`}
                           options={dynamicChartOptions.leak}
                           series={chartSeries.leak}
                           height={height}
@@ -426,7 +417,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="events" className="relative">
                       {currentTab === "events" && (
                         <Chart
-                          key={`events-${chartKey}-${useColumnsOverride}`}
+                          key={`events-${useColumnsOverride}`}
                           options={dynamicChartOptions.events}
                           series={chartSeries.events}
                           height={height}
@@ -437,7 +428,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="mask" className="relative">
                       {currentTab === "mask" && (
                         <Chart
-                          key={`mask-${chartKey}-${useColumnsOverride}`}
+                          key={`mask-${useColumnsOverride}`}
                           options={dynamicChartOptions.mask}
                           series={chartSeries.mask}
                           height={height}
@@ -448,7 +439,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="score" className="relative">
                       {currentTab === "score" && (
                         <Chart
-                          key={`score-${chartKey}-${useColumnsOverride}`}
+                          key={`score-${useColumnsOverride}`}
                           options={dynamicChartOptions.score}
                           series={chartSeries.score}
                           height={height}
@@ -459,7 +450,7 @@ function PageContent({ data }: { data: TAllData }) {
                     <TabsContent value="scoreBreakdown" className="relative">
                       {currentTab === "scoreBreakdown" && (
                         <Chart
-                          key={`scoreBreakdown-${chartKey}-${useColumnsOverride}`}
+                          key={`scoreBreakdown-${useColumnsOverride}`}
                           options={dynamicChartOptions.scoreBreakdown}
                           series={chartSeries.scoreBreakdown}
                           height={height}

--- a/src/app/sleep-data/page-content.tsx
+++ b/src/app/sleep-data/page-content.tsx
@@ -230,7 +230,7 @@ function PageContent({ data }: { data: TAllData }) {
       {/* <!-- Date Range Controls --> */}
       <div className="mb-6 inline-block rounded-lg p-4">
         <h1 className="mb-4 text-xl font-bold text-accent-500">
-          My{" "}
+          Kevin’s{" "}
           <span className="text-accent-600">
             Resmed <span className="font-normal">my</span>Air
           </span>{" "}

--- a/src/app/sleep-data/page-content.tsx
+++ b/src/app/sleep-data/page-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
 
 import dynamic from "next/dynamic";
@@ -31,36 +31,28 @@ function PageContent({ data }: { data: TAllData }) {
   });
   const [endDate, setEndDate] = useState(data.newestDate);
   const [useColumnsOverride, setUseColumnsOverride] = useState(() => INITIAL_STARTDATE_DAYS_AGO < LONG_RANGE_THRESHOLD);
-  const [pendingTab, setPendingTab] = useState<TTabNames | null>(null);
   const [currentTab, setCurrentTab] = useState<TTabNames>(INITIAL_TAB);
-  const toggleGen = useRef(0);
   const startTs = new Date(startDate).getTime();
   const endTs = new Date(endDate).getTime();
 
   const dayCount = Math.round((endTs - startTs) / (24 * 60 * 60 * 1000));
   const isLongRange = dayCount >= LONG_RANGE_THRESHOLD;
 
-  // Toggle between area and column chart for the current tab.
-  // Increment a generation counter to cancel stale toggles — if the user
-  // quickly switches tabs after clicking, the double-RAF fires after the new
-  // tab's render, and the gen check prevents toggling the wrong tab.
-  // The double-RAF lets React paint "Rendering…" before the expensive
-  // ApexCharts remount (single RAF is insufficient in practice).
   function toggleColumn() {
-    const gen = ++toggleGen.current;
-    setPendingTab(currentTab);
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        if (gen !== toggleGen.current) return;
-        setUseColumnsOverride((prev) => !prev);
-        setPendingTab(null);
-      });
-    });
+    setUseColumnsOverride((prev) => !prev);
   }
 
   function resetColumnsForRange(start: Date, end: Date) {
     const rangeDays = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000));
     setUseColumnsOverride(rangeDays < LONG_RANGE_THRESHOLD);
+  }
+
+  function renderTabChart(tab: TTabNames, height: number, width: number) {
+    if (currentTab !== tab) return null;
+
+    return (
+      <Chart key={tab} options={dynamicChartOptions[tab]} series={chartSeries[tab]} height={height} width={width} />
+    );
   }
 
   const filteredData = useMemo(() => {
@@ -85,41 +77,15 @@ function PageContent({ data }: { data: TAllData }) {
   }, [data, startTs, endTs]);
 
   const dynamicChartOptions: Record<TTabNames, ApexOptions> = useMemo(() => {
-    const areaStrokeMain: ApexOptions["stroke"] = { width: [2, 4] };
-    const areaStrokeBreakdown: ApexOptions["stroke"] = { width: [2, 2, 2, 2, 4] };
-    const colStrokeMain: ApexOptions["stroke"] = { width: [0, 4] };
-    const colStrokeBreakdown: ApexOptions["stroke"] = { width: [0, 0, 0, 0, 4] };
-    const areaFill: ApexOptions["fill"] = { type: "solid" };
-    const colFill: ApexOptions["fill"] = { type: "solid" };
-
     const getOpts = (key: TTabNames): ApexOptions => {
       const opts = chartOptions[key];
-      const useArea = !(useColumnsOverride && key === currentTab);
-
       if (key === "scoreBreakdown") {
-        if (useArea) {
-          const { plotOptions: _, ...noPlot } = opts;
-          return {
-            ...noPlot,
-            chart: { ...noPlot.chart!, animations: isLongRange ? { enabled: false } : { ...noPlot.chart!.animations, speed: 350 }, stackOnlyBar: false },
-            stroke: areaStrokeBreakdown,
-            fill: { type: "solid" },
-          };
-        }
         return {
           ...opts,
-          chart: { ...opts.chart, ...(isLongRange ? { animations: { enabled: false } } : {}) },
-          stroke: colStrokeBreakdown,
-          fill: colFill,
+          chart: { ...opts.chart, stackOnlyBar: false },
         };
       }
-
-      return {
-        ...opts,
-        chart: { ...opts.chart, ...(isLongRange ? { animations: { enabled: false } } : useArea ? { animations: { ...opts.chart!.animations, speed: 350 } } : {}) },
-        stroke: useArea ? areaStrokeMain : colStrokeMain,
-        fill: useArea ? areaFill : colFill,
-      };
+      return opts;
     };
 
     return {
@@ -130,7 +96,7 @@ function PageContent({ data }: { data: TAllData }) {
       score: getOpts("score"),
       scoreBreakdown: getOpts("scoreBreakdown"),
     };
-  }, [isLongRange, useColumnsOverride, currentTab]);
+  }, []);
 
   const chartSeries = useMemo(() => {
     const typeFor = (tab: TTabNames) => {
@@ -277,6 +243,7 @@ function PageContent({ data }: { data: TAllData }) {
             </label>
             <select
               id="preset-range"
+              autoComplete="off"
               className="rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
               value={selectedPreset}
               onChange={handlePresetChange}
@@ -301,6 +268,7 @@ function PageContent({ data }: { data: TAllData }) {
             <input
               type="date"
               id="start-date"
+              autoComplete="off"
               className="rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
               value={startDate}
               onChange={handleStartDateChange}
@@ -315,6 +283,7 @@ function PageContent({ data }: { data: TAllData }) {
             <input
               type="date"
               id="end-date"
+              autoComplete="off"
               className="rounded border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500"
               value={endDate}
               onChange={handleEndDateChange}
@@ -331,7 +300,6 @@ function PageContent({ data }: { data: TAllData }) {
               ]}
               value={useColumnsOverride ? "columns" : "area"}
               onChange={() => toggleColumn()}
-              disabled={pendingTab === currentTab}
             />
           </div>
         </div>
@@ -346,8 +314,6 @@ function PageContent({ data }: { data: TAllData }) {
                 onValueChange={(v) => {
                   setCurrentTab(v as TTabNames);
                   if (isLongRange) setUseColumnsOverride(!isLongRange);
-                  setPendingTab(null);
-                  toggleGen.current++;
                 }}
               >
                 <div className="pl-10">
@@ -393,70 +359,22 @@ function PageContent({ data }: { data: TAllData }) {
                 {!height || !width ? null : (
                   <>
                     <TabsContent value="hours" className="relative">
-                      {currentTab === "hours" && (
-                        <Chart
-                          key={`hours-${useColumnsOverride}`}
-                          options={dynamicChartOptions.hours}
-                          series={chartSeries.hours}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("hours", height, width)}
                     </TabsContent>
                     <TabsContent value="leak" className="relative">
-                      {currentTab === "leak" && (
-                        <Chart
-                          key={`leak-${useColumnsOverride}`}
-                          options={dynamicChartOptions.leak}
-                          series={chartSeries.leak}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("leak", height, width)}
                     </TabsContent>
                     <TabsContent value="events" className="relative">
-                      {currentTab === "events" && (
-                        <Chart
-                          key={`events-${useColumnsOverride}`}
-                          options={dynamicChartOptions.events}
-                          series={chartSeries.events}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("events", height, width)}
                     </TabsContent>
                     <TabsContent value="mask" className="relative">
-                      {currentTab === "mask" && (
-                        <Chart
-                          key={`mask-${useColumnsOverride}`}
-                          options={dynamicChartOptions.mask}
-                          series={chartSeries.mask}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("mask", height, width)}
                     </TabsContent>
                     <TabsContent value="score" className="relative">
-                      {currentTab === "score" && (
-                        <Chart
-                          key={`score-${useColumnsOverride}`}
-                          options={dynamicChartOptions.score}
-                          series={chartSeries.score}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("score", height, width)}
                     </TabsContent>
                     <TabsContent value="scoreBreakdown" className="relative">
-                      {currentTab === "scoreBreakdown" && (
-                        <Chart
-                          key={`scoreBreakdown-${useColumnsOverride}`}
-                          options={dynamicChartOptions.scoreBreakdown}
-                          series={chartSeries.scoreBreakdown}
-                          height={height}
-                          width={width}
-                        />
-                      )}
+                      {renderTabChart("scoreBreakdown", height, width)}
                     </TabsContent>
                   </>
                 )}

--- a/src/components/SegmentedToggle.tsx
+++ b/src/components/SegmentedToggle.tsx
@@ -26,7 +26,7 @@ function SegmentedToggle({ options, value, onChange, disabled }: SegmentedToggle
           if (!isFirstActive) onChange(first.value);
         }}
         className={clsx(
-          "relative px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          "relative px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50",
           "rounded-l-md",
           isFirstActive
             ? "z-10 border border-accent-600 bg-accent-500 text-white"
@@ -41,7 +41,7 @@ function SegmentedToggle({ options, value, onChange, disabled }: SegmentedToggle
           if (isFirstActive) onChange(second.value);
         }}
         className={clsx(
-          "relative px-3 py-1.5 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+          "relative px-3 py-1.5 text-sm font-medium transition-all duration-200 disabled:cursor-not-allowed disabled:opacity-50",
           "-ml-px rounded-r-md",
           !isFirstActive
             ? "z-10 border border-accent-600 bg-accent-500 text-white"


### PR DESCRIPTION
Always show chart type toggle with smart defaults, fix animation crash on long ranges and some other minor bugs

Highlights:
- Improvements to chart options
- UI "flash" problem while toggling is greatly improved, primarily due to changing `key` on Chart, letting the update its options and series in place. A big speed improvement from this, too, on the longer date ranges. Never has one small change gone so far, glory be.
- Consolidate six identical Chart rendering patterns into a single `renderTabChart` helper
- Add `autoComplete="off" `to the Date Range presets <select> and the Start Date / End Date <input type="date"> elements, so the browser does not restore their previous DOM state after hydration.
- Fix ApexCharts `w.dom.elDefs` crash and for other performance reasons: disable animations